### PR TITLE
Updated MeSH Model. Fixed descriptors and major topic.

### DIFF
--- a/openalexapi/mesh.py
+++ b/openalexapi/mesh.py
@@ -6,8 +6,8 @@ class Mesh(BaseModel):
     """This models the mesh object at OpenAlex.
     Unfortunately it does not contain the year when the term
     was added to MESH nor if it is still a valid MESH term"""
-    descriptor_ui: constr(max_length=7, min_length=7)
-    is_main_topic: bool
+    descriptor_ui: constr(max_length=10, min_length=7)
+    is_main_topic: Optional[bool]
     descriptor_name: str
     qualifier_ui: Optional[str]
     qualifier_name: Optional[str]

--- a/openalexapi/mesh.py
+++ b/openalexapi/mesh.py
@@ -7,7 +7,7 @@ class Mesh(BaseModel):
     Unfortunately it does not contain the year when the term
     was added to MESH nor if it is still a valid MESH term"""
     descriptor_ui: constr(max_length=10, min_length=7)
-    is_main_topic: Optional[bool]
+    is_major_topic: bool
     descriptor_name: str
     qualifier_ui: Optional[str]
     qualifier_name: Optional[str]


### PR DESCRIPTION
MeSH descriptors can be up to 10 characters long.  
REF: [https://www.nlm.nih.gov/pubs/techbull/ma13/ma13_mesh_ui_expand.html](https://www.nlm.nih.gov/pubs/techbull/ma13/ma13_mesh_ui_expand.html)

MeSH model `is_main_topic` should be `is_major_topic`.
REF: [https://docs.openalex.org/about-the-data/work#mesh](https://docs.openalex.org/about-the-data/work#mesh)